### PR TITLE
Check gamepad is identified as "OpenVR Gamepad"

### DIFF
--- a/lib/aframe-webvr-controller.js
+++ b/lib/aframe-webvr-controller.js
@@ -93,7 +93,7 @@
 
 				for (var i = 0; i < gamepads.length; ++i) {
 					var gamepad = gamepads[i];
-					if (gamepad && gamepad.pose) {
+					if (gamepad && gamepad.pose && gamepad.id === "OpenVR Gamepad") {
 						vrGamepads.push(gamepad);
 					}
 				}


### PR DESCRIPTION
When I have an Xbox 360 controller plugged in it occupies one of the gamepad slots, typically index 0. Xbox controllers aren't particularly useful for room scale.
